### PR TITLE
SNS認証の無効化

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,
-         :omniauthable
+         :recoverable, :rememberable, :validatable
+         # :omniauthable #SNS認証用
          # :confirmable #メール認証
 
   #Validation

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -35,9 +35,10 @@
             = f.select( :stuttering, [['吃音の症状あり', '吃音の症状あり'], ['吃音の症状なし', '吃音の症状なし'],['無回答', '無回答']],{},{class: "form-control"})
           .form-group.m-3
             = f.submit "登録", type: "submit",class: "btn btn-success"
-          .form-group.m-3
-            = link_to "Sign up with Twitter", user_twitter_omniauth_authorize_path
-          .form-group.m-3
-            = link_to "Sign up with Google", user_google_omniauth_authorize_path
+        / SNS認証を有効化するときはコメントを外して下さい
+        / .form-group.m-3
+        / = link_to "Sign up with Twitter", user_twitter_omniauth_authorize_path
+        / .form-group.m-3
+        / = link_to "Sign up with Google", user_google_omniauth_authorize_path
       .p-2
         = link_to "ログインはこちら" , new_user_session_path , class: "badge badge-pill badge-success text-white "

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -24,9 +24,10 @@
             = f.password_field :password, class: "form-control", placeholder: "パスワード"
           .form-group.m-3
             = f.submit "ログイン",class: "btn btn-success"
-          .form-group.m-3
-            = link_to "Sign up with Twitter", user_twitter_omniauth_authorize_path
-          .form-group.m-3
-            = link_to "Sign up with Google", user_google_omniauth_authorize_path
+        / SNS認証を有効化するときはコメントを外して下さい
+        / .form-group.m-3
+        / = link_to "Sign up with Twitter", user_twitter_omniauth_authorize_path
+        / .form-group.m-3
+        / = link_to "Sign up with Google", user_google_omniauth_authorize_path
       .p-2
         = link_to "新規登録はこちらから" , new_user_registration_path , class: "badge badge-pill badge-success text-white "

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
 
   get 'notifications/link_through'
-  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
+  devise_for :users
+   # controllers: { omniauth_callbacks: 'users/omniauth_callbacks' } #SNS認証を有効化するときにコメントを外して下さい
 
   root  'questions#index'                       #ルートパスの指定
   get '/questions/category/:sort', to: "questions#index"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2018_10_16_013216) do
 
   create_table "answer_likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
#WHAT
SNS認証の無効化

#WHY
今は不要なため
有効化する際は、このブランチでコメントアウトしている箇所を元に戻してください。